### PR TITLE
add mode 3 to just dump data

### DIFF
--- a/src/models/calo_variance.cpp
+++ b/src/models/calo_variance.cpp
@@ -69,83 +69,109 @@ double variance(const std::vector<double> & vec, double avg){
     return sum_devsq / vec.size();
 }
 
-int main(int argc, char* argv[]){
+int mode_one(int argc, char* argv[]){
+    int seed = atoi(argv[3]);
+    to_file(argv[2], seed);
+    return 0;
+}
 
-    if (argc < 2) {
-        std::cout << "need mode" << std::endl;
-        return 1;
-    }
-
-    int mode = atoi(argv[1]);
-
-    std::cout << "the variance: mode: " << mode << std::endl;
-
-    if (mode == 1) {
-        int seed = atoi(argv[3]);
-        to_file(argv[2], seed);
-    }
-
+int mode_two(int argc, char* argv[]){
     auto voxel_value_lists =
         std::vector<std::vector<std::vector<std::vector<double>>>>(35,
             std::vector<std::vector<std::vector<double>>>(35,
               std::vector<std::vector<double>>(20,std::vector<double>())
             )
         );
+    std::size_t n_iterations = atoi(argv[5]);
 
-    if (mode == 2) {
-        std::size_t n_iterations = atoi(argv[5]);
+    for(std::size_t iter = 0; iter<n_iterations;++iter){
+        if (iter % 100 == 0) { std::cout << "iter: " << iter << std::endl; }
+        auto calo_histo = generate_response_from_file(argv[2]);
+        for (std::size_t ix = 0; ix < calo_histo.size(); ++ix) {
+            for (std::size_t iy = 0; iy < calo_histo[ix].size(); ++iy) {
+                for (std::size_t iz = 0; iz < calo_histo[ix][iy].size(); ++iz) {
 
-        for(std::size_t iter = 0; iter<n_iterations;++iter){
-            if (iter % 100 == 0) { std::cout << "iter: " << iter << std::endl; }
-            auto calo_histo = generate_response_from_file(argv[2]);
-            for (std::size_t ix = 0; ix < calo_histo.size(); ++ix) {
-                for (std::size_t iy = 0; iy < calo_histo[ix].size(); ++iy) {
-                    for (std::size_t iz = 0; iz < calo_histo[ix][iy].size(); ++iz) {
-
-                        // std::cout << "val: " << calo_histo[ix][iy][iz] << std::endl;
-                        voxel_value_lists[ix][iy][iz].push_back(calo_histo[ix][iy][iz]);
-                        // std::cout << "voxl: " << voxel_value_lists[ix][iy][iz] << std::endl;
-                    }
+                    // std::cout << "val: " << calo_histo[ix][iy][iz] << std::endl;
+                    voxel_value_lists[ix][iy][iz].push_back(calo_histo[ix][iy][iz]);
+                    // std::cout << "voxl: " << voxel_value_lists[ix][iy][iz] << std::endl;
                 }
             }
         }
-
-
-
-        auto avg =
-            std::vector<std::vector<std::vector<double>>>(35,
-                std::vector<std::vector<double>>(35,
-                    std::vector<double>(20)
-                 )
-            );
-        auto var =
-            std::vector<std::vector<std::vector<double>>>(35,
-                std::vector<std::vector<double>>(35,
-                    std::vector<double>(20)
-                )
-            );
-
-
-        for (std::size_t ix = 0; ix < voxel_value_lists.size(); ++ix){
-            for (std::size_t iy = 0; iy < voxel_value_lists[ix].size(); ++iy){
-                for (std::size_t iz = 0; iz < voxel_value_lists[ix][iy].size(); ++iz){
-                    double avg_val = average(voxel_value_lists[ix][iy][iz]);
-                    double var_val  = variance(voxel_value_lists[ix][iy][iz], avg_val);
-                    // std::cout << "vox: " << voxel_value_lists[ix][iy][iz] << " var: " << var_val << " avg: " << avg_val << std::endl;
-                    avg[ix][iy][iz] = avg_val;
-                    var[ix][iy][iz] = var_val;
-                }
-            }
-        }
-
-        std::ofstream avg_f(argv[3]);
-        avg_f << avg;
-
-        std::ofstream var_f(argv[4]);
-        var_f << var;
-
     }
 
+
+
+    auto avg =
+        std::vector<std::vector<std::vector<double>>>(35,
+            std::vector<std::vector<double>>(35,
+                std::vector<double>(20)
+             )
+        );
+    auto var =
+        std::vector<std::vector<std::vector<double>>>(35,
+            std::vector<std::vector<double>>(35,
+                std::vector<double>(20)
+            )
+        );
+
+
+    for (std::size_t ix = 0; ix < voxel_value_lists.size(); ++ix){
+        for (std::size_t iy = 0; iy < voxel_value_lists[ix].size(); ++iy){
+            for (std::size_t iz = 0; iz < voxel_value_lists[ix][iy].size(); ++iz){
+                double avg_val = average(voxel_value_lists[ix][iy][iz]);
+                double var_val  = variance(voxel_value_lists[ix][iy][iz], avg_val);
+                // std::cout << "vox: " << voxel_value_lists[ix][iy][iz] << " var: " << var_val << " avg: " << avg_val << std::endl;
+                avg[ix][iy][iz] = avg_val;
+                var[ix][iy][iz] = var_val;
+            }
+        }
+    }
+
+    std::ofstream avg_f(argv[3]);
+    avg_f << avg;
+
+    std::ofstream var_f(argv[4]);
+    var_f << var;
+    return 0;
+}
+
+void dump_to_stream(const char* source_file, std::ostream& stream, std::size_t n_iterations){
+  for(std::size_t iter = 0; iter<n_iterations;++iter){
+      if (iter % 100 == 0) { std::cerr << "iter: " << iter << std::endl; }
+      auto calo_histo = generate_response_from_file(source_file);
+      stream << calo_histo << std::endl;
+  }
+}
+
+int mode_three(int argc, char* argv[]){
+  std::cerr << "generating a bunch of data" << std::endl;
+  std::size_t n_iterations = atoi(argv[4]);
+  auto source = argv[2];
+  if(strcmp(argv[3],"-")==0){
+    dump_to_stream(source, std::cout , n_iterations);
+  }
+  else{
+    std::ofstream f(argv[3]);
+    dump_to_stream(source, f , n_iterations);
+  }
+  return 0;
+}
+
+int main(int argc, char* argv[]){
+    if (argc < 2) {
+        std::cerr << "need mode" << std::endl;
+        return 1;
+    }
+
+    int mode = atoi(argv[1]);
+
+    std::cerr << "the variance: mode: " << mode << std::endl;
+
+    switch (mode) {
+      case 1: return mode_one(argc, argv);
+      case 2: return mode_two(argc, argv);
+      case 3: return mode_three(argc, argv);
+    }
 
     return 0;
 }

--- a/src/models/calorimeter.cpp
+++ b/src/models/calorimeter.cpp
@@ -63,13 +63,13 @@ std::vector<double> orient(const std::vector<double>& v, double theta, double ph
 
 std::pair<double,std::vector<double> > shower_parameters(int pdg_id){
     if(Rivet::PID::isElectron(pdg_id) or Rivet::PID::isPhoton(pdg_id)){
-        std::cout << "EM-type shower parameters" << std::endl;
+        // std::cout << "EM-type shower parameters" << std::endl;
         double sampling_fraction = 0.5;
         std::vector<double> shapepars{0.2,0.2,0.50};
         return std::make_pair(sampling_fraction, shapepars);
     }
     if(Rivet::PID::isHadron(pdg_id)){
-        std::cout << "HAD-type shower parameters" << std::endl;
+        // std::cout << "HAD-type shower parameters" << std::endl;
         double sampling_fraction = 0.25;
         std::vector<double> shapepars{0.2,0.2,1.00};
         return std::make_pair(sampling_fraction, shapepars);
@@ -123,8 +123,8 @@ double particle_calorimeter_response(
         // std::cout << "SHERPAPROBPROG SPACEPOINT" << s[0] << "," << s[1] << "," << s[2] << std::endl;
         auto idx = get_indices(s,calo_segmentation);
         if(idx[0] < 0 || idx[1] < 0 || idx[2] < 0){
-            std::cout << "skip spacepoint: " << s << std::endl;
-            std::cout << "indices: " << idx << std::endl;
+            // std::cout << "skip spacepoint: " << s << std::endl;
+            // std::cout << "indices: " << idx << std::endl;
             continue;
         }
         float edep = min_energy_deposit();
@@ -137,7 +137,7 @@ double particle_calorimeter_response(
 
 std::vector<std::vector<std::vector<double > > > calo_simulation(const std::vector<std::vector<double> >& particle_data){
 
-    std::cout << "simulating calo response of " << particle_data.size() << " particles" << std::endl;
+    // std::cout << "simulating calo response of " << particle_data.size() << " particles" << std::endl;
 
     int NBINX = 35;
     int NBINY = 35;
@@ -166,7 +166,7 @@ std::vector<std::vector<std::vector<double > > > calo_simulation(const std::vect
 
         if(pdg_id == -99999) continue;
         if(!calo_visible){
-          std::cout << "invisible particle" << std::endl;
+          // std::cout << "invisible particle" << std::endl;
           continue;
         }
 


### PR DESCRIPTION
adds `mode==3` to the calo_variance cli app.

Usage:

```
/code/CPProb/build/src/models/calo_variance 3 example.dat - 10000|gzip > /out/events.gz
```

this would dump 10k events to stdout (best to use compression to write to disk)